### PR TITLE
Beta/se arguments, skipping chr/bp and p_sig correction (v1.0.8)

### DIFF
--- a/mtag.py
+++ b/mtag.py
@@ -243,7 +243,7 @@ def load_and_merge_data(args):
         GWAS_d[p] =GWAS_d[p].rename(columns={x+str(p):x for x in GWAS_d[p].columns})
         GWAS_d[p] = GWAS_d[p].rename(columns={args.snp_name+str(p):args.snp_name})
 
-        # Drop SNPs that are missing 
+        # Drop SNPs that are missing
         missing_snps = GWAS_d[p][args.snp_name].isin(['NA','.'])
         M0 = len(GWAS_d[p])
         GWAS_d[p] = GWAS_d[p][np.logical_not(missing_snps)]
@@ -330,7 +330,7 @@ def load_and_merge_data(args):
 
 
     ## Parse chromosomes
-    if args.only_chr is not None:
+    if args.only_chr is not None and not args.no_chr_data:
         chr_toInclude = args.only_chr.split(',')
         chr_toInclude = [int(c) for c in chr_toInclude]
         GWAS_all = GWAS_all[GWAS_all[args.chr_name+str(0)].isin(chr_toInclude)]
@@ -534,8 +534,12 @@ def extract_gwas_sumstats(DATA, args):
     # results_template = pd.DataFrame(index=np.arange(len(DATA)))
     # results_template.loc[:,args.snp_name] = DATA[args.snp_name]
     # args.chr args.bpos args.alelle_names
-    for col in [args.chr_name, args.bpos_name, args.a1_name, args.a2_name]:
-        results_template.loc[:,col] = DATA[col+str(0)]
+    if args.no_chr_data:
+        for col in [args.a1_name, args.a2_name]:
+           results_template.loc[:,col] = DATA[col+str(0)]
+    else:
+        for col in [args.chr_name, args.bpos_name, args.a1_name, args.a2_name]:
+            results_template.loc[:,col] = DATA[col+str(0)]
     # TODO: non-error form of integer conversion
     # results_template[args.chr_name] = results_template[args.chr_name].astype(int)
     # results_template[args.bpos_name] = results_template[args.bpos_name].astype(int)
@@ -1281,6 +1285,7 @@ input_formatting.add_argument("--beta_name", default="beta", help="The common na
 input_formatting.add_argument("--se_name", default=None, help="The common name of the column of standard errors of the betas across all input files. Default is the lowercase letter z. Must be specified with --beta_name.")
 input_formatting.add_argument("--n_name", default="n", help="the common name of the column of sample sizes in the GWAS summary statistics files. Default is the lowercase letter  n.")
 input_formatting.add_argument('--eaf_name',default="freq", help="The common name of the column of minor allele frequencies (MAF) in the GWAS input files. The default is \"freq\".")
+input_formatting.add_argument('--no_chr_data',default=False,action='store_true', help="If used, will not use information related to the chromosome and base pair position columns. Use only it chromosome/base pair positional data is missing, but are certain that the snpids correctly identify the SNPs across traits.")
 input_formatting.add_argument('--chr_name',default='chr', type=str, help="Name of the column containing the chromosome of each SNP in the GWAS input. Default is \"chr\".")
 input_formatting.add_argument('--bpos_name',default='bpos', type=str, help="Name of the column containing the base pair of each SNP in the GWAS input. Default is \"bpos\".")
 input_formatting.add_argument('--a1_name',default='a1', type=str, help="Name of the column containing the effect allele of each SNP in the GWAS input. Default is \"a1\".")

--- a/mtag.py
+++ b/mtag.py
@@ -129,6 +129,7 @@ class Logger_to_Logging(object):
 def _perform_munge(args, GWAS_df, GWAS_dat_gen,p):
 
     merge_alleles = None
+    
     out = None
     if args.beta_name is not None:
         GWAS_df['z'] = GWAS_df[args.beta_name] / GWAS_df[args.se_name]
@@ -1281,7 +1282,7 @@ out_opts.add_argument("--meta_format", default=False, action="store_true",
 input_formatting = parser.add_argument_group(title="Column names of input files", description="These options manually pass the names of the relevant summary statistics columns used by MTAG. It is recommended to pass these names because only narrow searches for these columns are performed in the default cases. Moreover, it is necessary that these input files be readable by ldsc's munge_sumstats command.")
 input_formatting.add_argument("--snp_name", default="snpid", action="store",type=str, help="Name of the single column that provides the unique identifier for SNPs in the GWAS summary statistics across all GWAS results. Default is \"snpid\". This the index that will be used to merge the GWAS summary statistics. Any SNP lists passed to ---include or --exclude should also contain the same name.")
 input_formatting.add_argument("--z_name", default="z", help="The common name of the column of Z scores across all input files. Default is the lowercase letter z.")
-input_formatting.add_argument("--beta_name", default="beta", help="The common name of the column of beta coefficients (effect sizes) across all input files. Must be specified with se. If specified, it will override the z-score column.")
+input_formatting.add_argument("--beta_name", default=None, help="The common name of the column of beta coefficients (effect sizes) across all input files. Must be specified with se. If specified, it will override the z-score column.")
 input_formatting.add_argument("--se_name", default=None, help="The common name of the column of standard errors of the betas across all input files. Default is the lowercase letter z. Must be specified with --beta_name.")
 input_formatting.add_argument("--n_name", default="n", help="the common name of the column of sample sizes in the GWAS summary statistics files. Default is the lowercase letter  n.")
 input_formatting.add_argument('--eaf_name',default="freq", help="The common name of the column of minor allele frequencies (MAF) in the GWAS input files. The default is \"freq\".")

--- a/mtag.py
+++ b/mtag.py
@@ -20,7 +20,7 @@ from ldsc_mod.ldscore import allele_info
 
 import ldsc_mod.munge_sumstats as munge_sumstats
 
-__version__ = '1.0.7'
+__version__ = '1.0.8'
 
 borderline = "<><><<>><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><><>"
 

--- a/mtag.py
+++ b/mtag.py
@@ -1277,7 +1277,9 @@ out_opts = parser.add_argument_group(title="Output formatting", description="Set
 out_opts.add_argument("--out", metavar='DIR/PREFIX', default='./mtag_results', type=str, help='Specify the directory and name prefix to output MTAG results. All mtag results will be prefixed with the corresponding tag. Default is ./mtag_results')
 out_opts.add_argument("--make_full_path", default=False, action="store_true", help="option to make output path specified in -out if it does not exist.")
 out_opts.add_argument("--meta_format", default=False, action="store_true",
-    help="Highly suggested to only use this with the --perfect_gencov option. In addition to the typical results file that are restricted to the intersection of SNPs across files, this creates a file of the union of SNPs, with applications of the MTAG estimator restricted to the set of traits for which that SNP is available.")
+    help=argparse.SUPPRESS)
+
+    #"Highly suggested to only use this with the --perfect_gencov option. In addition to the typical results file that are restricted to the intersection of SNPs across files, this creates a file of the union of SNPs, with applications of the MTAG estimator restricted to the set of traits for which that SNP is available.")
 
 input_formatting = parser.add_argument_group(title="Column names of input files", description="These options manually pass the names of the relevant summary statistics columns used by MTAG. It is recommended to pass these names because only narrow searches for these columns are performed in the default cases. Moreover, it is necessary that these input files be readable by ldsc's munge_sumstats command.")
 input_formatting.add_argument("--snp_name", default="snpid", action="store",type=str, help="Name of the single column that provides the unique identifier for SNPs in the GWAS summary statistics across all GWAS results. Default is \"snpid\". This the index that will be used to merge the GWAS summary statistics. Any SNP lists passed to ---include or --exclude should also contain the same name.")

--- a/mtag.py
+++ b/mtag.py
@@ -1327,7 +1327,7 @@ fdr_opts.add_argument('--intervals', default=10, action='store',type=int, help='
 
 fdr_opts.add_argument('--cores', default=1, action='store', type=int, help='Number of threads/cores use to compute the FDR grid points for each trait.')
 
-fdr_opts.add_argument('--p_sig', default=5.0e-8, action='store', help='P-value threshold used for statistical signifiance. Default is p=5.0e-8 (genome-wide significance).' )
+fdr_opts.add_argument('--p_sig', default=5.0e-8, type=float, action='store', help='P-value threshold used for statistical signifiance. Default is p=5.0e-8 (genome-wide significance).' )
 fdr_opts.add_argument('--n_approx', default=False, action='store_true', help='Speed up FDR calculation by replacing the sample size of a SNP for each trait by the mean across SNPs (for each trait). Recommended.')
 
 # fdr_opts.add_argument('--binned_n', default=False, action='store_true', help='When --n_approx is off, this options allows for a sped-up version of the max_FDR calculation by weighting the power calculations of unique rows.')


### PR DESCRIPTION
hi @huilisabrina, 

Can you review the following update to the mtag (now version 1.0.8)? Changes made:

- added `--beta_name` and `--se_name` options that can be used in place of `--z_name`. Note this pair of options overrides that `--z_name`, even if it is included.
-  corrected --p_sig argument type from #23 
- added option to avoid including chromosome/bp data.



