### PR TITLE
fix p_sig input to float

### DIFF
--- a/mtag.py
+++ b/mtag.py
@@ -899,7 +899,7 @@ def scale_omega(gen_corr_mat, priors, S=None):
 
 def compute_fdr(prob, t, omega, sigma, S, Ns,N_counts, p_threshold):
 
-    z_threshold = scipy.stats.norm.isf(p_threshold / 2.) # magnitude of z-score needed for statistical significance
+    z_threshold = scipy.stats.norm.isf(float(p_threshold) / 2.) # magnitude of z-score needed for statistical significance
     n_S, T = S.shape
 
     omega_TT = scale_omega(omega, prob, S)


### PR DESCRIPTION
When passing in p_sig when doing FDR calculation with a personalized value such as 1e-5, it was interpreted as a string and showed "unsupported operand type(s) for /: 'str' and 'float'". After fixing it, it could run smoothly to the end with FDR results.